### PR TITLE
Ability to configure the tag names read from the project file

### DIFF
--- a/versionintovariables/task.json
+++ b/versionintovariables/task.json
@@ -12,6 +12,13 @@
         "Minor": 0,
         "Patch": 0
     },
+    "groups": [
+        {
+            "name": "advanced",
+            "displayName": "Advanced",
+            "isExpanded": false
+        }
+    ],
     "demands": [],
     "inputs": [{
             "name": "path",
@@ -24,6 +31,22 @@
             "type": "string",
             "label": "Variables Prefix",
             "helpMarkDown": "Prefix to append to variables, if desired."
+        },
+        {
+            "name": "versionTag",
+            "type": "string",
+            "groupName": "advanced",
+            "defaultValue": "ApplicationVersion",
+            "label": "Version Tag Name",
+            "helpMarkDown": "Name of the tag that holds the version information in your project file."
+        },
+        {
+            "name": "revisionTag",
+            "type": "string",
+            "groupName": "advanced",
+            "defaultValue": "ApplicationRevision",
+            "label": "Revision Tag Name",
+            "helpMarkDown": "Name of the tag that holds the revison information in your project file."
         }
     ],
     "instanceNameFormat": "Get Application Version as variables from $(path)",

--- a/versionintovariables/versionintovariables.ts
+++ b/versionintovariables/versionintovariables.ts
@@ -10,6 +10,8 @@ const workingDir: string = tl.getVariable('System.DefaultWorkingDirectory');
 const projectFilePath: string = tl.getPathInput('path', true, true);
 let prefix: string = tl.getInput('prefix');
 prefix = prefix ? prefix + '.' : '';
+let versionTagName: string = tl.getInput('versionTag');
+let revisionTagName: string = tl.getInput('revisionTag');
 async function run() {
     try {
         tl.debug(`File Path: ${projectFilePath}`);
@@ -17,8 +19,8 @@ async function run() {
         const projFiles = tl.findMatch(workingDir, projectFilePath);
         projFiles.forEach((file) => {
             const doc: Document = new Parser.DOMParser().parseFromString(fs.readFileSync(file, { encoding: 'utf8' }));
-            const versionElem = doc.getElementsByTagName('ApplicationVersion').item(0);
-            const revisionElem = doc.getElementsByTagName('ApplicationRevision').item(0);
+            const versionElem = doc.getElementsByTagName(versionTagName).item(0);
+            const revisionElem = doc.getElementsByTagName(revisionTagName).item(0);
 
             const version = versionElem.textContent.split('.');
             tl.setVariable(`${prefix}Version.Major`, version[0]);


### PR DESCRIPTION
The task "Get Application Version As Variables" can be configured to specify the name of the tags where version and revision should be looked. It uses the existing default values, but they can be overridden in the Advanced tab. Useful for net core projects that don't specify "ApplicationVersion" as the version holder.

#5 